### PR TITLE
Add the setting to save/restore window size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ jspm_packages
 
 # Directories for packages
 sbe-*
+scrapbox-darwin-x64
 
 # idea
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,3 @@ jspm_packages
 
 # Directories for packages
 sbe-*
-scrapbox-darwin-x64
-
-# idea
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ jspm_packages
 
 # Directories for packages
 sbe-*
+
+# idea
+.idea

--- a/main.js
+++ b/main.js
@@ -6,10 +6,22 @@ const path = require("path");
 const url = require("url");
 const Menu = electron.Menu;
 
+const fs = require("fs");
+
 let mainWindow;
 
+const info_path = path.join(app.getPath("userData"), "bounds-info.json");
+
 const createWindow = () => {
-  mainWindow = new BrowserWindow({ width: 1024, height: 800 });
+  let bounds_info;
+
+  try {
+    bounds_info = JSON.parse(fs.readFileSync(info_path, 'utf-8'))
+  } catch (e) {
+    bounds_info = {width:800, height:1000}
+  }
+
+  mainWindow = new BrowserWindow(bounds_info);
 
   mainWindow.loadURL(
     url.format({
@@ -20,6 +32,10 @@ const createWindow = () => {
   );
 
   initWindowMenu();
+
+  mainWindow.on("close", () => {
+    fs.writeFileSync(info_path, JSON.stringify(mainWindow.getBounds()))
+  })
 
   mainWindow.on("closed", () => {
     mainWindow = null;

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ const createWindow = () => {
   try {
     bounds_info = JSON.parse(fs.readFileSync(info_path, 'utf-8'))
   } catch (e) {
-    bounds_info = {width:800, height:1000}
+    bounds_info = {width: 1024, height: 800}
   }
 
   mainWindow = new BrowserWindow(bounds_info);

--- a/main.js
+++ b/main.js
@@ -1,16 +1,14 @@
 const electron = require("electron");
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
+const Menu = electron.Menu;
 
 const path = require("path");
 const url = require("url");
-const Menu = electron.Menu;
-
 const fs = require("fs");
+const info_path = path.join(app.getPath("userData"), "bounds-info.json");
 
 let mainWindow;
-
-const info_path = path.join(app.getPath("userData"), "bounds-info.json");
 
 const createWindow = () => {
   let bounds_info;


### PR DESCRIPTION
Hello. I usually use your code as a desktop application of Scrapbox.
This pull request adds the setting to save/restore window size and position.
If you do not need it, reject this request.

こんにちは。普段からScrapboxのデスクトップアプリとして使わせてもらっています。
個人的にあると嬉しいと思ったので、前回終了時のウィンドウのサイズと位置を保持する設定を追加しました。
必要なければrejectしてください。