### PR TITLE
fix: Make CI less flakier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       run: npx playwright install
     - name: Run Test
       run: npm test
+      env:
+        RUN_MODE: test
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: ${{ always() }}

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -52,7 +52,8 @@ async function createWindow () {
   });
   mainWindow.webContents.on('did-finish-load', async () => {
     await loadStartPage();
-    await loadPage('https://scrapbox.io');
+    // await loadPage('https://scrapbox.io');
+    await loadFavPage();
   });
   await notifyUpdate();
 }

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -52,8 +52,11 @@ async function createWindow () {
   });
   mainWindow.webContents.on('did-finish-load', async () => {
     await loadStartPage();
-    // await loadPage('https://scrapbox.io');
-    await loadFavPage();
+    if (process.env.RUN_MODE === 'test') {
+      await loadFavPage();
+    } else {
+      await loadPage('https://scrapbox.io');
+    }
   });
   await notifyUpdate();
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+// this test requires the following environment variables
+// - RUN_MODE: test
 import { _electron, test, expect } from '@playwright/test';
 
 let electronApp;
@@ -7,7 +9,7 @@ test.beforeEach(async ({ page }, testInfo) => {
   console.log(`Running ${testInfo.title}`);
   electronApp = await _electron.launch({ args: ['src/main.mjs'] });
   mainWindow = await electronApp.firstWindow();
-  await mainWindow.waitForTimeout(5000);
+  await mainWindow.waitForTimeout(1000);
 });
 
 test.afterEach(async ({ page }, testInfo) => {
@@ -24,7 +26,11 @@ test('launch app', async () => {
 
   const windows = await electronApp.windows();
   expect(windows.length).toBe(3);
-  //expect(await windows[1].title()).toBe('Start page');
+
+  const titles = await Promise.all(windows.map(async (window) => await window.title()));
+  expect(titles).toContain('Start page');
+  expect(titles).toContain('Fav list');
+
   await windows[1].screenshot({ path: './test-results/child1.png' });
   await windows[2].screenshot({ path: './test-results/child2.png' });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,7 @@ test('launch app', async () => {
 
   const windows = await electronApp.windows();
   expect(windows.length).toBe(3);
-  expect(await windows[1].title()).toBe('Start page');
+  //expect(await windows[1].title()).toBe('Start page');
   await windows[1].screenshot({ path: './test-results/child1.png' });
   await windows[2].screenshot({ path: './test-results/child2.png' });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,7 @@ test('launch app', async () => {
   // expect(windows.length).toBe(3);
   expect(await windows[1].title()).toBe('Start page');
   await windows[1].screenshot({ path: './test-results/child1.png' });
-  // await windows[2].screenshot({ path: './test-results/child2.png' });
+  await windows[2].screenshot({ path: './test-results/child2.png' });
 });
 
 async function isPackaged () {

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,8 @@ test('launch app', async () => {
   expect(packaged).toBe(false);
 
   const windows = await electronApp.windows();
+  await mainWindow.waitForTimeout(5000);
+
   expect(windows.length).toBe(3);
   expect(await windows[1].title()).toBe('Start page');
   await windows[1].screenshot({ path: './test-results/child1.png' });

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,7 @@ test.beforeEach(async ({ page }, testInfo) => {
   console.log(`Running ${testInfo.title}`);
   electronApp = await _electron.launch({ args: ['src/main.mjs'] });
   mainWindow = await electronApp.firstWindow();
-  await mainWindow.waitForTimeout(1000);
+  await mainWindow.waitForTimeout(3000);
 });
 
 test.afterEach(async ({ page }, testInfo) => {

--- a/test/test.js
+++ b/test/test.js
@@ -23,12 +23,12 @@ test('launch app', async () => {
   expect(packaged).toBe(false);
 
   const windows = await electronApp.windows();
-  await mainWindow.waitForTimeout(5000);
+  // await mainWindow.waitForTimeout(5000);
 
-  expect(windows.length).toBe(3);
+  // expect(windows.length).toBe(3);
   expect(await windows[1].title()).toBe('Start page');
   await windows[1].screenshot({ path: './test-results/child1.png' });
-  await windows[2].screenshot({ path: './test-results/child2.png' });
+  // await windows[2].screenshot({ path: './test-results/child2.png' });
 });
 
 async function isPackaged () {

--- a/test/test.js
+++ b/test/test.js
@@ -23,9 +23,7 @@ test('launch app', async () => {
   expect(packaged).toBe(false);
 
   const windows = await electronApp.windows();
-  // await mainWindow.waitForTimeout(5000);
-
-  // expect(windows.length).toBe(3);
+  expect(windows.length).toBe(3);
   expect(await windows[1].title()).toBe('Start page');
   await windows[1].screenshot({ path: './test-results/child1.png' });
   await windows[2].screenshot({ path: './test-results/child2.png' });


### PR DESCRIPTION
This pull request includes several changes aimed at improving the test environment and refining the test cases. The most important changes include adding an environment variable for test mode, modifying the application behavior based on this variable, and updating the test cases to accommodate these changes.

### Test Environment Improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR38-R39): Added `RUN_MODE: test` environment variable to the test run step.

### Application Behavior Modifications:

* [`src/main.mjs`](diffhunk://#diff-bdb7c6e508bc49c6d5091f329374fb3fec8f0a0c351f43a15b4676f22c03b865R55-R59): Modified `createWindow` function to load a different page when `RUN_MODE` is set to `test`.

### Test Case Updates:

* [`test/test.js`](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fR1-R2): Added comments to indicate required environment variables and updated test assertions to check for multiple window titles. [[1]](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fR1-R2) [[2]](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fL27-R33)
* [`test/test.js`](diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fL10-R12): Reduced the timeout in `beforeEach` hook from 5000ms to 3000ms.