### PR TITLE
fix: disable asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "build": {
     "productName": "sbe",
     "appId": "sbe",
+    "asar": false,
     "mac": {
       "icon": "icons/mac/sbe.icns"
     },


### PR DESCRIPTION
Disable asar archiving to avoid startup errors with electron-builder package when updating to Electron v35.0.0.