### PR TITLE
fix: MenuItem visibility is ignored so add filtering

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -518,7 +518,8 @@ function prepareMenu() {
 function prepareContextMenu(content) {
   content.on('context-menu', (e, params) => {
     const menuTemplate = buildContextMenu(params, content);
-    const contextMenu = Menu.buildFromTemplate(menuTemplate);
+    const visibleItems = menuTemplate.filter(item => item.visible);
+    const contextMenu = Menu.buildFromTemplate(visibleItems);
     contextMenu.popup({ window: content });
   });
 }


### PR DESCRIPTION
In Electron v34+, Menu.buildFromTemplate ignores the visibility of menuItem, so I filter it myself to avoid this.