### PR TITLE
chore: Use tag_name to get latest release tag

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -1050,7 +1050,10 @@ async function notifyUpdate() {
     const res = await fetch("https://api.github.com/repos/kondoumh/sbe/releases/latest");
     if (res.status === 200) {
       const data = await res.json();
-      const latest = data.name;
+      const latest = (data.tag_name || data.name || '').replace(/^v/i, '');
+      if (!/^\d+\.\d+\.\d+([-.+].+)?$/.test(latest)) {
+        return;
+      }
       if (compareVersions(latest, app.getVersion()) === 1) {
         new Notification({ title: 'sbe', body: 'New version avilable!' }).on('click', () =>{
           shell.openExternal('https://github.com/kondoumh/sbe/releases/latest');


### PR DESCRIPTION
This pull request improves the version update notification logic in `src/main.mjs` by making the extraction and validation of the latest version number more robust.

Update notification improvements:

* Changed how the latest version is determined by prioritizing `data.tag_name`, then `data.name`, and normalizing it by removing a leading `v` if present.
* Added a validation step to ensure the extracted version matches the expected semantic versioning format before proceeding with the notification.